### PR TITLE
Enable editing of task comments

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -967,6 +967,19 @@ header {
             right: 1.5rem;
             transition: opacity 0.2s;
         }
+        .edit-comment {
+            cursor: pointer;
+            color: var(--text-secondary);
+            opacity: 0.7;
+            position: absolute;
+            top: 0;
+            right: 3rem;
+            transition: opacity 0.2s;
+        }
+        .edit-comment:hover {
+            opacity: 1;
+            color: var(--primary-color);
+        }
         .ack-comment:hover {
             opacity: 1;
             color: var(--primary-color);

--- a/dashboard.js
+++ b/dashboard.js
@@ -219,6 +219,13 @@ const commentsList = document.getElementById('commentsList');
 const newCommentText = document.getElementById('newCommentText');
 const newCommentAuthor = document.getElementById('newCommentAuthor');
 const addCommentBtn = document.getElementById('addCommentBtn');
+const cancelEditCommentBtn = document.getElementById('cancelEditCommentBtn');
+const itemCommentsSection = document.getElementById('itemCommentsSection');
+const itemCommentsList = document.getElementById('itemCommentsList');
+const itemCommentText = document.getElementById('itemCommentText');
+const itemCommentAuthor = document.getElementById('itemCommentAuthor');
+const itemAddCommentBtn = document.getElementById('itemAddCommentBtn');
+const itemCancelEditCommentBtn = document.getElementById('itemCancelEditCommentBtn');
 const ganttZoomIn = document.getElementById('ganttZoomIn');
 const ganttZoomOut = document.getElementById('ganttZoomOut');
 const openGanttModalBtn = document.getElementById('openGanttModalBtn');
@@ -2336,10 +2343,18 @@ document.getElementById('itemPhase').value = task.Phase || '';
 Array.from(predecessorSelect.options).forEach(o => { if (Array.isArray(task.Predecessors) && task.Predecessors.includes(o.value)) o.selected = true; });
 Array.from(successorSelect.options).forEach(o => { if (Array.isArray(task.Successors) && task.Successors.includes(o.value)) o.selected = true; });
 toggleModalFields();
+if (itemCommentsSection) {
+  itemCommentsSection.classList.remove('hidden');
+  populateItemComments(taskId);
+}
 }
 } else {
 modalTitle.textContent = 'Add New Item';
 updateStatusOptions(itemTypeSelect.value);
+if (itemCommentsSection) {
+  itemCommentsSection.classList.add('hidden');
+  itemCommentTaskId = null;
+}
 }
 
 addItemModal.style.display = 'flex';
@@ -2387,39 +2402,74 @@ opt.style.display = opt.textContent.toLowerCase().includes(f) ? '' : 'none';
 }
 
 function hideAddItemModal() {
-addItemModal.classList.remove('show');
-addItemModal.style.display = 'none';
-editingTaskId = null;
-const modalTitle = addItemModal.querySelector('.modal-header h2');
-if (modalTitle) modalTitle.textContent = 'Add New Item';
+  addItemModal.classList.remove('show');
+  addItemModal.style.display = 'none';
+  editingTaskId = null;
+  const modalTitle = addItemModal.querySelector('.modal-header h2');
+  if (modalTitle) modalTitle.textContent = 'Add New Item';
+}
+
+function populateItemComments(taskId) {
+  itemCommentTaskId = taskId;
+  itemEditingCommentIndex = null;
+  if (!itemCommentsSection) return;
+  const task = window.allTaskData.find(t => t.TaskID === taskId);
+  const comments = task && Array.isArray(task.Comments) ? task.Comments : [];
+  if (comments.length > 0) {
+    itemCommentsList.innerHTML = comments.map((c, idx) => {
+      const textWithMentions = c.text.replace(/@(\w+)/g, '<span class="mention">@$1</span>');
+      return `<div class="comment-entry ${c.acknowledged ? 'acknowledged' : ''}" data-comment-index="${idx}" style="margin-bottom:8px; position:relative;">
+        <strong>${c.author}</strong> (${new Date(c.timestamp).toLocaleString()}):<br>${textWithMentions}
+        <span class="material-icons edit-comment" data-comment-index="${idx}">edit</span>
+        <span class="material-icons ack-comment" data-comment-index="${idx}">check_circle</span>
+        <span class="material-icons delete-comment" data-comment-index="${idx}">delete</span>
+      </div>`;
+    }).join('');
+  } else {
+    itemCommentsList.innerHTML = '<p>No comments yet.</p>';
+  }
+  itemCommentText.value = '';
+  itemCommentAuthor.value = '';
+  itemAddCommentBtn.textContent = 'Add Comment';
+  itemCancelEditCommentBtn.classList.add('hidden');
 }
 
 let currentCommentTaskId = null;
+let editingCommentIndex = null;
+let itemCommentTaskId = null;
+let itemEditingCommentIndex = null;
 
 function showCommentsModal(taskId) {
-currentCommentTaskId = taskId;
-const task = window.allTaskData.find(t => t.TaskID === taskId);
-const comments = task && Array.isArray(task.Comments) ? task.Comments : [];
-if (comments.length > 0) {
-commentsList.innerHTML = comments.map((c, idx) => {
-const textWithMentions = c.text.replace(/@(\w+)/g, '<span class="mention">@$1</span>');
-return `
+  currentCommentTaskId = taskId;
+  editingCommentIndex = null;
+  const task = window.allTaskData.find(t => t.TaskID === taskId);
+  const comments = task && Array.isArray(task.Comments) ? task.Comments : [];
+  if (comments.length > 0) {
+    commentsList.innerHTML = comments.map((c, idx) => {
+      const textWithMentions = c.text.replace(/@(\w+)/g, '<span class="mention">@$1</span>');
+      return `
 <div class="comment-entry ${c.acknowledged ? 'acknowledged' : ''}" data-comment-index="${idx}" style="margin-bottom:8px; position:relative;">
 <strong>${c.author}</strong> (${new Date(c.timestamp).toLocaleString()}):<br>${textWithMentions}
+<span class="material-icons edit-comment" data-comment-index="${idx}">edit</span>
 <span class="material-icons ack-comment" data-comment-index="${idx}">check_circle</span>
 <span class="material-icons delete-comment" data-comment-index="${idx}">delete</span>
 </div>`;
-}).join('');
-} else {
-commentsList.innerHTML = '<p>No comments yet.</p>';
-}
-newCommentText.value = '';
-newCommentAuthor.value = '';
-commentsModal.classList.add('show');
+    }).join('');
+  } else {
+    commentsList.innerHTML = '<p>No comments yet.</p>';
+  }
+  newCommentText.value = '';
+  newCommentAuthor.value = '';
+  addCommentBtn.textContent = 'Add Comment';
+  cancelEditCommentBtn.classList.add('hidden');
+  commentsModal.classList.add('show');
 }
 
 function hideCommentsModal() {
-commentsModal.classList.remove('show');
+  commentsModal.classList.remove('show');
+  editingCommentIndex = null;
+  addCommentBtn.textContent = 'Add Comment';
+  cancelEditCommentBtn.classList.add('hidden');
 }
 
 function showProjectInfoModal() {
@@ -3310,31 +3360,67 @@ closeCommentsBtn.addEventListener('click', hideCommentsModal);
 commentsModal.addEventListener('click', (e) => {
 if (e.target === commentsModal) hideCommentsModal();
 });
+cancelEditCommentBtn.addEventListener('click', () => {
+  editingCommentIndex = null;
+  newCommentText.value = '';
+  newCommentAuthor.value = '';
+  addCommentBtn.textContent = 'Add Comment';
+  cancelEditCommentBtn.classList.add('hidden');
+});
 addCommentBtn.addEventListener('click', async () => {
-if (!currentCommentTaskId) return;
-const task = window.allTaskData.find(t => t.TaskID === currentCommentTaskId);
-if (!task) return;
-const text = newCommentText.value.trim();
-if (!text) return;
-const author = newCommentAuthor.value.trim() || 'Anonymous';
-const mentionRegex = /@(\w+)/g;
-const mentions = Array.from(text.matchAll(mentionRegex)).map(m => m[1]);
-const knownNames = new Set(window.allTaskData.map(t => (t.Owner || '').toLowerCase()));
-const validMentions = mentions.filter(m => knownNames.has(m.toLowerCase()));
-const comment = { author, text, timestamp: new Date().toISOString(), acknowledged: false };
-if (validMentions.length > 0) {
-comment.mentions = validMentions;
-showToast(`Mentioned: ${validMentions.join(', ')}`);
-}
-if (!Array.isArray(task.Comments)) task.Comments = [];
-task.Comments.push(comment);
-showToast('Comment added');
-await saveProjectData();
-window.applyFilters();
-hideCommentsModal();
+  if (!currentCommentTaskId) return;
+  const task = window.allTaskData.find(t => t.TaskID === currentCommentTaskId);
+  if (!task) return;
+  const text = newCommentText.value.trim();
+  if (!text) return;
+  const author = newCommentAuthor.value.trim() || 'Anonymous';
+  const mentionRegex = /@(\w+)/g;
+  const mentions = Array.from(text.matchAll(mentionRegex)).map(m => m[1]);
+  const knownNames = new Set(window.allTaskData.map(t => (t.Owner || '').toLowerCase()));
+  const validMentions = mentions.filter(m => knownNames.has(m.toLowerCase()));
+
+  if (!Array.isArray(task.Comments)) task.Comments = [];
+
+  if (editingCommentIndex !== null && task.Comments[editingCommentIndex]) {
+    const existing = task.Comments[editingCommentIndex];
+    existing.text = text;
+    existing.author = author;
+    existing.timestamp = new Date().toISOString();
+    if (validMentions.length > 0) {
+      existing.mentions = validMentions;
+      showToast(`Mentioned: ${validMentions.join(', ')}`);
+    }
+    showToast('Comment updated');
+  } else {
+    const comment = { author, text, timestamp: new Date().toISOString(), acknowledged: false };
+    if (validMentions.length > 0) {
+      comment.mentions = validMentions;
+      showToast(`Mentioned: ${validMentions.join(', ')}`);
+    }
+    task.Comments.push(comment);
+    showToast('Comment added');
+  }
+
+  await saveProjectData();
+  window.applyFilters();
+  showCommentsModal(currentCommentTaskId);
 });
 
 commentsList.addEventListener('click', async (e) => {
+const edit = e.target.closest('.edit-comment');
+if (edit) {
+  const idx = parseInt(edit.dataset.commentIndex, 10);
+  const task = window.allTaskData.find(t => t.TaskID === currentCommentTaskId);
+  if (task && Array.isArray(task.Comments) && task.Comments[idx]) {
+    const c = task.Comments[idx];
+    newCommentText.value = c.text;
+    newCommentAuthor.value = c.author;
+    editingCommentIndex = idx;
+    addCommentBtn.textContent = 'Save Comment';
+    cancelEditCommentBtn.classList.remove('hidden');
+  }
+  return;
+}
 const del = e.target.closest('.delete-comment');
 if (del) {
 const idx = parseInt(del.dataset.commentIndex, 10);
@@ -3358,6 +3444,93 @@ window.applyFilters();
 showToast('Comment updated');
 }
 }
+});
+
+itemCancelEditCommentBtn.addEventListener('click', () => {
+  itemEditingCommentIndex = null;
+  itemCommentText.value = '';
+  itemCommentAuthor.value = '';
+  itemAddCommentBtn.textContent = 'Add Comment';
+  itemCancelEditCommentBtn.classList.add('hidden');
+});
+
+itemAddCommentBtn.addEventListener('click', async () => {
+  if (!itemCommentTaskId) return;
+  const task = window.allTaskData.find(t => t.TaskID === itemCommentTaskId);
+  if (!task) return;
+  const text = itemCommentText.value.trim();
+  if (!text) return;
+  const author = itemCommentAuthor.value.trim() || 'Anonymous';
+  const mentionRegex = /@(\w+)/g;
+  const mentions = Array.from(text.matchAll(mentionRegex)).map(m => m[1]);
+  const knownNames = new Set(window.allTaskData.map(t => (t.Owner || '').toLowerCase()));
+  const validMentions = mentions.filter(m => knownNames.has(m.toLowerCase()));
+
+  if (!Array.isArray(task.Comments)) task.Comments = [];
+
+  if (itemEditingCommentIndex !== null && task.Comments[itemEditingCommentIndex]) {
+    const existing = task.Comments[itemEditingCommentIndex];
+    existing.text = text;
+    existing.author = author;
+    existing.timestamp = new Date().toISOString();
+    if (validMentions.length > 0) {
+      existing.mentions = validMentions;
+      showToast(`Mentioned: ${validMentions.join(', ')}`);
+    }
+    showToast('Comment updated');
+  } else {
+    const comment = { author, text, timestamp: new Date().toISOString(), acknowledged: false };
+    if (validMentions.length > 0) {
+      comment.mentions = validMentions;
+      showToast(`Mentioned: ${validMentions.join(', ')}`);
+    }
+    task.Comments.push(comment);
+    showToast('Comment added');
+  }
+
+  await saveProjectData();
+  populateItemComments(itemCommentTaskId);
+});
+
+itemCommentsList.addEventListener('click', async (e) => {
+  const edit = e.target.closest('.edit-comment');
+  if (edit) {
+    const idx = parseInt(edit.dataset.commentIndex, 10);
+    const task = window.allTaskData.find(t => t.TaskID === itemCommentTaskId);
+    if (task && Array.isArray(task.Comments) && task.Comments[idx]) {
+      const c = task.Comments[idx];
+      itemCommentText.value = c.text;
+      itemCommentAuthor.value = c.author;
+      itemEditingCommentIndex = idx;
+      itemAddCommentBtn.textContent = 'Save Comment';
+      itemCancelEditCommentBtn.classList.remove('hidden');
+    }
+    return;
+  }
+  const del = e.target.closest('.delete-comment');
+  if (del) {
+    const idx = parseInt(del.dataset.commentIndex, 10);
+    const task = window.allTaskData.find(t => t.TaskID === itemCommentTaskId);
+    if (task && Array.isArray(task.Comments)) {
+      task.Comments.splice(idx, 1);
+      await saveProjectData();
+      populateItemComments(itemCommentTaskId);
+      showToast('Comment deleted');
+    }
+    return;
+  }
+  const ack = e.target.closest('.ack-comment');
+  if (ack) {
+    const idx = parseInt(ack.dataset.commentIndex, 10);
+    const task = window.allTaskData.find(t => t.TaskID === itemCommentTaskId);
+    if (task && Array.isArray(task.Comments) && task.Comments[idx]) {
+      task.Comments[idx].acknowledged = !task.Comments[idx].acknowledged;
+      await saveProjectData();
+      populateItemComments(itemCommentTaskId);
+      window.applyFilters();
+      showToast('Comment updated');
+    }
+  }
 });
 
 filterButton.addEventListener('click', () => {

--- a/index.html
+++ b/index.html
@@ -480,6 +480,16 @@
                     <input type="text" id="successorFilter" class="modal-filter-input" placeholder="Filter tasks">
                     <select id="successorSelect" name="Successors" multiple></select>
                 </div>
+                <div id="itemCommentsSection" class="form-field hidden">
+                    <label>Comments</label>
+                    <div id="itemCommentsList" style="max-height: 150px; overflow-y: auto; margin-bottom: 10px;"></div>
+                    <textarea id="itemCommentText" placeholder="Add a comment" style="width: 100%; height: 80px;"></textarea>
+                    <input type="text" id="itemCommentAuthor" placeholder="Your name" style="width: 100%; margin-top: 5px;" />
+                    <div class="filter-buttons" style="margin-top: 10px;">
+                        <button id="itemAddCommentBtn" class="filter-btn">Add Comment</button>
+                        <button id="itemCancelEditCommentBtn" class="reset-btn hidden">Cancel</button>
+                    </div>
+                </div>
                 <div class="filter-buttons" style="margin-top: 20px;">
                     <button type="button" id="saveCloseBtn" class="filter-btn">Save &amp; Close</button>
                 </div>
@@ -514,6 +524,7 @@
             <input type="text" id="newCommentAuthor" placeholder="Your name" style="width: 100%; margin-top: 5px;" />
             <div class="filter-buttons" style="margin-top: 10px;">
                 <button id="addCommentBtn" class="filter-btn">Add Comment</button>
+                <button id="cancelEditCommentBtn" class="reset-btn hidden">Cancel</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- integrate comment editing section in Edit Item modal
- populate comments when editing a task
- support add, update, acknowledge, and delete within the modal

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686b38570d6c832f85a4f11f6632d4e4