### PR TITLE
Add row checkbox selection from Gantt

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ bars for each task. The setting is saved so your preference persists when you
 reopen the dashboard.
 
 Click any bar in the Gantt chart to highlight the corresponding row in the task
-table.
+table. The row's select checkbox is checked automatically and previous
+selections are cleared so only one row stays selected.
 
 ### Kanban Board
 

--- a/dashboard.js
+++ b/dashboard.js
@@ -1396,13 +1396,17 @@ function highlightTableRowById(taskId) {
     if (!taskMatrixTableBody) return;
     const rows = taskMatrixTableBody.querySelectorAll('tr');
     rows.forEach(row => {
+        const cb = row.querySelector('.task-select');
         if (row.dataset.taskId === String(taskId)) {
             row.classList.add('highlight-row');
+            if (cb) cb.checked = true;
             row.scrollIntoView({ behavior: 'smooth', block: 'center' });
         } else {
             row.classList.remove('highlight-row');
+            if (cb) cb.checked = false;
         }
     });
+    updateSelectedActionsVisibility();
 }
 
 function attachGanttClick(gantt) {


### PR DESCRIPTION
## Summary
- when clicking a Gantt bar, uncheck other rows and check the clicked row's checkbox
- document single-selection behaviour in README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686b41726074832fb2dcb8b498ebc96e