### PR TITLE
Limit Gantt bar click selection to view mode

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -1418,7 +1418,10 @@ function attachGanttClick(gantt) {
         if (bar._clickHandler) {
             bar.group.removeEventListener('click', bar._clickHandler);
         }
-        bar._clickHandler = () => highlightTableRowById(id);
+        bar._clickHandler = () => {
+            // Only highlight the related table row when not in Gantt edit mode
+            if (!ganttEditMode) highlightTableRowById(id);
+        };
         bar.group.addEventListener('click', bar._clickHandler);
     });
 }


### PR DESCRIPTION
## Summary
- avoid highlighting a table row on bar click when Gantt edit mode is active

## Testing
- `npm test --silent | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_686b4522ad20832fab9b16dfb266e492