### PR TITLE
Limit Gantt bar click selection to view mode

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -688,12 +688,12 @@ header {
             cursor: grab; /* indicate chart can be dragged */
         }
 
-        /* Disable pointer events on task bars unless in edit mode */
+        /* Allow pointer events on task bars in both modes so clicks work */
 
         .gantt-container:not(.edit-mode) .bar-wrapper,
         .gantt-container:not(.edit-mode) .bar,
         .gantt-container:not(.edit-mode) .handle {
-            pointer-events: none;
+            pointer-events: auto;
         }
 
         /* When editing, allow dragging tasks but still pan by clicking empty space */

--- a/dashboard.js
+++ b/dashboard.js
@@ -1418,7 +1418,10 @@ function attachGanttClick(gantt) {
         if (bar._clickHandler) {
             bar.group.removeEventListener('click', bar._clickHandler);
         }
-        bar._clickHandler = () => highlightTableRowById(id);
+        bar._clickHandler = () => {
+            // Only highlight the related table row when not in Gantt edit mode
+            if (!ganttEditMode) highlightTableRowById(id);
+        };
         bar.group.addEventListener('click', bar._clickHandler);
     });
 }


### PR DESCRIPTION
## Summary
- avoid highlighting a table row on bar click when Gantt edit mode is active
- keep pointer events enabled on Gantt bars in view mode so row selection works

## Testing
- `npm test --silent | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_686b4522ad20832fab9b16dfb266e492