### PR TITLE
Add gantt label color persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,6 +384,8 @@
     </div>
     <input type="color" id="cellTextColorPicker" class="table-color-picker cell-color-picker" title="Pick a text color then click the check icon to apply">
     <button id="applyCellTextColorBtn" class="zoom-btn cell-color-apply-btn" title="Apply selected color"><span class="material-icons">check</span></button>
+    <input type="color" id="ganttLabelColorPicker" class="table-color-picker cell-color-picker" title="Pick a text color then click the check icon to apply">
+    <button id="applyGanttLabelColorBtn" class="zoom-btn cell-color-apply-btn" title="Apply selected color"><span class="material-icons">check</span></button>
 
     <!-- Add Item Modal -->
     <div id="addItemModal" class="modal-overlay">


### PR DESCRIPTION
## Summary
- allow custom font color on each Gantt bar label
- persist label color in project data so it remains after page reload

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686b4bcd2a4c832fa7a0c7073c51a9ca