### PR TITLE
Add side task list for Gantt chart

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -16,6 +16,7 @@
             --drawer-rail-width: 5rem;
             --drawer-background: linear-gradient(180deg, #FFFFFF 0%, #E8F0FE 100%);
             --scrollbar-thumb-color: #C8C8C8;
+            --gantt-row-height: 30px;
 
             /* Status Colors - Gemini Palette */
             --status-done: #34A853; /* Green */
@@ -686,6 +687,27 @@ header {
             overflow-x: auto; /* enable horizontal scrolling */
             overflow-y: auto; /* allow vertical scrolling for long charts */
             cursor: grab; /* indicate chart can be dragged */
+        }
+
+        .gantt-wrapper {
+            display: grid;
+            grid-template-columns: 200px 1fr;
+            overflow: hidden;
+        }
+
+        .gantt-task-list {
+            border-right: 1px solid var(--divider-color);
+            overflow-y: auto;
+        }
+
+        .gantt-task-row {
+            height: var(--gantt-row-height);
+            display: flex;
+            align-items: center;
+            padding-left: 0.5rem;
+            font-size: 0.85em;
+            border-bottom: 1px solid var(--divider-color);
+            background: var(--card-background);
         }
 
         /* Allow pointer events on task bars in both modes so clicks work */

--- a/dashboard.js
+++ b/dashboard.js
@@ -1588,6 +1588,29 @@ function createGanttChart(elementId, data, labelKey, startKey, endKey) {
     attachGanttLabelContextMenu(gantt);
     positionGanttLabelsLeft(gantt);
     charts[elementId] = gantt;
+    if (elementId === 'ganttChart') {
+        const wrapper = container.closest('.gantt-wrapper');
+        if (wrapper) {
+            const list = wrapper.querySelector('#ganttTaskList');
+            const scrollContainer = wrapper.parentElement;
+            if (list && scrollContainer) {
+                list.innerHTML = '';
+                tasks.forEach(t => {
+                    if (t.Type === 'MilestoneRow') return;
+                    const row = document.createElement('div');
+                    row.className = 'gantt-task-row';
+                    row.textContent = t.name;
+                    list.appendChild(row);
+                });
+                scrollContainer.addEventListener('scroll', () => {
+                    list.scrollTop = scrollContainer.scrollTop;
+                });
+                list.addEventListener('scroll', () => {
+                    scrollContainer.scrollTop = list.scrollTop;
+                });
+            }
+        }
+    }
     const idx = ganttViewModes.indexOf(viewMode);
     currentGanttView = idx !== -1 ? idx : ganttViewModes.indexOf('Day');
     if (elementId === 'ganttChart' && ganttViewModeSelect) {

--- a/index.html
+++ b/index.html
@@ -288,8 +288,11 @@
                         <button id="openGanttModalBtn" class="zoom-btn" title="Focus Mode"><span class="material-icons">fullscreen</span></button>
                     </div>
                 </div>
-                 <div class="gantt-container">
-                    <div id="ganttChart"></div>
+                <div class="gantt-container">
+                    <div id="ganttWrapper" class="gantt-wrapper">
+                        <div id="ganttTaskList" class="gantt-task-list"></div>
+                        <div id="ganttChart"></div>
+                    </div>
                 </div>
                 <div class="legend-container" id="ganttLegend">
                     <div class="legend-group">


### PR DESCRIPTION
## Summary
- show a task list beside the main Gantt chart
- style new task list panel
- sync scrolling between task list and chart

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bb2421134832f9d516477b6decbc9