### PR TITLE
Add status-based colors and icons

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -882,9 +882,16 @@ header {
 
         .progress-bar {
             height: 100%;
-            background-color: var(--status-in-progress);
             border-radius: 4px;
         }
+
+        .progress-bar.status-done { background-color: var(--status-done); }
+        .progress-bar.status-in-progress { background-color: var(--status-in-progress); }
+        .progress-bar.status-on-hold { background-color: var(--status-on-hold); }
+        .progress-bar.status-at-risk { background-color: var(--status-at-risk); }
+        .progress-bar.status-open { background-color: var(--status-open); }
+        .progress-bar.status-resolved { background-color: var(--status-resolved); }
+        .progress-bar.status-not-started { background-color: var(--status-not-started); }
         
         .progress-text {
             position: absolute;

--- a/dashboard.js
+++ b/dashboard.js
@@ -1023,9 +1023,11 @@ const hasIssues = window.allTaskData.some(i => i.ParentID === task.TaskID && i.T
 const issueIconHtml = hasIssues ? `<span class="material-icons" style="color: var(--status-at-risk); font-size: 1em; vertical-align: middle;">bug_report</span>` : '';
 const delayIconHtml = isOverdue ? `<span class="material-icons" style="color: var(--status-at-risk); font-size: 1em; vertical-align: middle;">schedule</span>` : '';
 const expandIcon = isParent ? `<span class="material-icons expand-toggle">${task._isCollapsed ? 'chevron_right' : 'expand_more'}</span>` : `<span style="width: 24px; display: inline-block;"></span>`;
+const typeIconHtml = getTypeIcon(task.Type);
 cell.innerHTML = `
 <div class="task-name-cell">
 ${expandIcon}
+${typeIconHtml}
 <span data-field-name="Task Name">${task['Task Name']}</span>
 ${issueIconHtml}
 ${delayIconHtml}
@@ -1059,10 +1061,11 @@ break;
 case 'Progress (%)':
     if (task.Type !== 'Vehicle Milestone') {
         const progress = parseInt(task['Progress (%)'] || 0);
+        const statusClass = task.Status ? `status-${task.Status.toLowerCase().replace(/ /g, '-')}` : '';
         cell.classList.add('progress-cell');
         cell.innerHTML = `
 <div class="progress-bar-container">
-    <div class="progress-bar" style="width: ${progress}%;"></div>
+    <div class="progress-bar ${statusClass}" style="width: ${progress}%;"></div>
     <span class="progress-text">${progress}%</span>
 </div>
 `;


### PR DESCRIPTION
## Summary
- color progress bars based on task status
- show task type icon inside task name column

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686bd7c8bff4832f9caf483feaf91063