### PR TITLE
Add option to hide Gantt task list

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ The **Show Baselines** checkbox lets you toggle visibility of dashed baseline
 bars for each task. The setting is saved so your preference persists when you
 reopen the dashboard.
 
+Click the sidebar icon next to the baseline toggle to hide or show the task list
+column if you need more space for the timeline.
+
 Click any bar in the Gantt chart to highlight the corresponding row in the task
 table. The row's select checkbox is checked automatically and previous
 selections are cleared so only one row stays selected.

--- a/dashboard.css
+++ b/dashboard.css
@@ -725,6 +725,15 @@ header {
             min-width: 100%;
         }
 
+        /* Hide task list column when toggled */
+        .gantt-container.hide-task-list .gmainleft {
+            display: none;
+        }
+        .gantt-container.hide-task-list .gmainright {
+            flex: 1 1 auto;
+            width: 100%;
+        }
+
         .legend-container {
             display: flex;
             flex-wrap: wrap;

--- a/dashboard.js
+++ b/dashboard.js
@@ -283,9 +283,11 @@ const deleteAllBtn = document.getElementById('deleteAllBtn');
 const switchKanbanBtn = document.getElementById('switchKanbanBtn');
 const baselineToggle = document.getElementById('baselineToggle');
 const toggleBaselineBtn = document.getElementById('toggleBaselineBtn');
+const toggleTaskListBtn = document.getElementById('toggleTaskListBtn');
 const toggleGanttEditBtn = document.getElementById('toggleGanttEditBtn');
 const toggleGanttModalEditBtn = document.getElementById('toggleGanttModalEditBtn');
 loadBaselineVisibilityState();
+loadTaskListVisibilityState();
 const kanbanContainer = document.getElementById('kanbanContainer');
 const tableSearchInput = document.getElementById('tableSearchInput');
 const editProjectInfoBtn = document.getElementById('editProjectInfoBtn');
@@ -384,6 +386,7 @@ window.allTaskData = [];
 let charts = {};
 let currentTableFontSize = 14;
 let baselineVisible = true;
+let ganttTaskListVisible = true;
 let ganttEditMode = false;
 let ganttTotalDateRange = { min: null, max: null };
 let editingTaskId = null;
@@ -624,12 +627,35 @@ async function loadBaselineVisibilityState() {
     }
 }
 
+// Load persisted task list visibility flag
+async function loadTaskListVisibilityState() {
+    try {
+        const stored = await get('ganttTaskListVisible');
+        if (typeof stored === 'boolean') {
+            ganttTaskListVisible = stored;
+        }
+    } catch (error) {
+        console.error('Failed to load task list state:', error);
+    }
+    updateTaskListButton();
+    applyTaskListVisibility();
+}
+
 // Persist current baseline visibility flag
 async function saveBaselineVisibilityState() {
     try {
         await set('baselineVisible', baselineVisible);
     } catch (error) {
         console.error('Failed to save baseline state:', error);
+    }
+}
+
+// Persist current task list visibility flag
+async function saveTaskListVisibilityState() {
+    try {
+        await set('ganttTaskListVisible', ganttTaskListVisible);
+    } catch (error) {
+        console.error('Failed to save task list state:', error);
     }
 }
 
@@ -667,6 +693,23 @@ function updateGanttEditButtons() {
             '<span class="material-icons">edit</span>' :
             '<span class="material-icons">pan_tool</span>';
     }
+}
+
+function updateTaskListButton() {
+    if (!toggleTaskListBtn) return;
+    if (ganttTaskListVisible) {
+        toggleTaskListBtn.title = 'Hide Task List';
+        toggleTaskListBtn.innerHTML = '<span class="material-icons">view_sidebar</span>';
+    } else {
+        toggleTaskListBtn.title = 'Show Task List';
+        toggleTaskListBtn.innerHTML = '<span class="material-icons">view_stream</span>';
+    }
+}
+
+function applyTaskListVisibility() {
+    ganttContainers.forEach(c => {
+        c.classList.toggle('hide-task-list', !ganttTaskListVisible);
+    });
 }
 
 // --- Core Functions ---
@@ -3693,6 +3736,15 @@ if (toggleBaselineBtn) {
         saveBaselineVisibilityState();
         updateBaselineButton();
         // Baseline display not supported with jsGanttImproved
+    });
+}
+
+if (toggleTaskListBtn) {
+    toggleTaskListBtn.addEventListener('click', () => {
+        ganttTaskListVisible = !ganttTaskListVisible;
+        saveTaskListVisibilityState();
+        updateTaskListButton();
+        applyTaskListVisibility();
     });
 }
 

--- a/index.html
+++ b/index.html
@@ -284,6 +284,7 @@
                             <option value="Quarter Day">Quarter Day</option>
                         </select>
                         <button id="toggleBaselineBtn" class="zoom-btn" title="Hide Baselines"><span class="material-icons">visibility_off</span></button>
+                        <button id="toggleTaskListBtn" class="zoom-btn" title="Hide Task List"><span class="material-icons">view_sidebar</span></button>
                         <button id="toggleGanttEditBtn" class="zoom-btn" title="Enable Edit Mode"><span class="material-icons">pan_tool</span></button>
                         <button id="openGanttModalBtn" class="zoom-btn" title="Focus Mode"><span class="material-icons">fullscreen</span></button>
                     </div>


### PR DESCRIPTION
## Summary
- add toggle button to hide the task list in the Gantt chart
- store task list visibility using IndexedDB
- style hidden state in CSS and document the feature

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c94195008832f801ab8011ceec2e8