### PR TITLE
Add progress labels to jsGantt bars

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -1338,6 +1338,9 @@ function initJsGantt(elementId, tasks) {
 
     const gantt = new JSGantt.GanttChart(container, 'day');
     if (!gantt) return null;
+    gantt.setOptions({
+        vCaptionType: 'Caption'
+    });
 
     tasks.forEach(t => {
         gantt.AddTaskItemObject({
@@ -1354,7 +1357,7 @@ function initJsGantt(elementId, tasks) {
             pParent: t.parentID || 0,
             pOpen: 1,
             pDepend: t.dependencies || '',
-            pCaption: '',
+            pCaption: t.name,
             pNotes: t.progress_detail || ''
         });
     });

--- a/vendor/jsgantt-improved/dist/jsgantt.css
+++ b/vendor/jsgantt-improved/dist/jsgantt.css
@@ -259,14 +259,11 @@ span.gfoldercollapse {
   font-size: 9px;
   text-align: left;
   white-space: nowrap;
-  top: 1px;
   position: absolute;
   top: 2px;
-}
-
-.ggroupcaption,
-.gcaption {
-  right: -126px;
+  left: 4px;
+  right: auto;
+  color: #fff;
 }
 
 /* Task complete %age bar shared attributes */


### PR DESCRIPTION
## Summary
- display task name on jsGantt bars instead of progress
- style bar captions so they appear inside the bar

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686ca1b714cc832fba590d15e727151e