### PR TITLE
Refine Gantt edit mode icon

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -684,13 +684,13 @@ function updateGanttEditButtons() {
         toggleGanttEditBtn.title = ganttEditMode ? disableTitle : enableTitle;
         toggleGanttEditBtn.innerHTML = ganttEditMode ?
             '<span class="material-icons">edit</span>' :
-            '<span class="material-icons">pan_tool</span>';
+            '<span class="material-icons">view_timeline</span>';
     }
     if (toggleGanttModalEditBtn) {
         toggleGanttModalEditBtn.title = ganttEditMode ? disableTitle : enableTitle;
         toggleGanttModalEditBtn.innerHTML = ganttEditMode ?
             '<span class="material-icons">edit</span>' :
-            '<span class="material-icons">pan_tool</span>';
+            '<span class="material-icons">view_timeline</span>';
     }
     if (ganttViewModeSelect) ganttViewModeSelect.disabled = !ganttEditMode;
     if (ganttViewModeModalSelect) ganttViewModeModalSelect.disabled = !ganttEditMode;

--- a/index.html
+++ b/index.html
@@ -287,7 +287,7 @@
                         </select>
                         <button id="toggleBaselineBtn" class="zoom-btn" title="Hide Baselines"><span class="material-icons">visibility_off</span></button>
                         <button id="toggleTaskListBtn" class="zoom-btn" title="Hide Task List"><span class="material-icons">view_sidebar</span></button>
-                        <button id="toggleGanttEditBtn" class="zoom-btn" title="Enable Edit Mode"><span class="material-icons">pan_tool</span></button>
+                        <button id="toggleGanttEditBtn" class="zoom-btn" title="Enable Edit Mode"><span class="material-icons">view_timeline</span></button>
                         <button id="openGanttModalBtn" class="zoom-btn" title="Focus Mode"><span class="material-icons">fullscreen</span></button>
                     </div>
                 </div>
@@ -598,7 +598,7 @@
                         <option value="Half Day">Half Day</option>
                         <option value="Quarter Day">Quarter Day</option>
                     </select>
-                    <button id="toggleGanttModalEditBtn" class="zoom-btn" title="Enable Edit Mode"><span class="material-icons">pan_tool</span></button>
+                    <button id="toggleGanttModalEditBtn" class="zoom-btn" title="Enable Edit Mode"><span class="material-icons">view_timeline</span></button>
                 </div>
                 <button class="modal-close" id="closeGanttModalBtn">&times;</button>
             </div>


### PR DESCRIPTION
## Summary
- use `view_timeline` icon when edit mode is disabled
- keep `edit` icon when editing

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686cd8edebd4832f8ba008c4bcaf8de7